### PR TITLE
Remove unnecessary @types/get-stdin package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,13 +1835,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/get-stdin": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "get-stdin": "*"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "8.0.1",
       "dev": true,
@@ -8390,7 +8383,6 @@
       "license": "MIT",
       "dependencies": {
         "@commitlint/is-ignored": "^17.4.2",
-        "@types/get-stdin": "^7.0.0",
         "chalk": "^4.1.2",
         "get-stdin": "^9.0.0",
         "yargs": "^17.6.2"
@@ -9517,7 +9509,6 @@
         "@mediamonks/prettier-config": "^1.0.1",
         "@swc/core": "^1.3.27",
         "@swc/jest": "^0.2.24",
-        "@types/get-stdin": "^7.0.0",
         "@types/jest": "^29.2.3",
         "@types/shelljs": "^0.8.11",
         "chalk": "^4.1.2",
@@ -9676,12 +9667,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
-      }
-    },
-    "@types/get-stdin": {
-      "version": "7.0.0",
-      "requires": {
-        "get-stdin": "*"
       }
     },
     "@types/glob": {

--- a/packages/commitlint-issue-reference/package.json
+++ b/packages/commitlint-issue-reference/package.json
@@ -108,14 +108,13 @@
     "tsm": "^2.3.0",
     "typescript": "^5.0.4"
   },
-  "engines": {
-    "node": ">=16.0.0"
-  },
   "dependencies": {
     "@commitlint/is-ignored": "^17.4.2",
-    "@types/get-stdin": "^7.0.0",
     "chalk": "^4.1.2",
     "get-stdin": "^9.0.0",
     "yargs": "^17.6.2"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
The get-stdin packages ships it's own types, during installation a warning is logged.